### PR TITLE
parse returns a lazy seq of vectors and delimiter support

### DIFF
--- a/src/opencsv_clj/core.clj
+++ b/src/opencsv_clj/core.clj
@@ -5,17 +5,23 @@
   (:require [clojure.java.io :as io]))
 
 
-(defn- read-csv [path delimiter]
-  "Reads a csv file and generates a lazy sequence of rows. If delimiter is nil, the default (\\,) is used."
+(defn- read-csv-from-reader [reader delimiter]
   (let [buffer (if (nil? delimiter)
-		 (CSVReader. (io/reader path))
-		 (CSVReader. (io/reader path) delimiter))]
+		 (CSVReader. reader)
+		 (CSVReader. reader delimiter))]
     (lazy-seq
      (loop [res []]
        (if-let [nxt (.readNext buffer)]
-         (recur (conj res (seq nxt)))
-         res)))))
+	 (recur (conj res (seq nxt)))
+	 res)))))
 
+(defn- read-csv [path delimiter]
+  "Reads a csv file and generates a lazy sequence of rows. If delimiter is nil, the default (\\,) is used."
+  (read-csv-from-reader (io/reader path) delimiter))
+
+(defn- read-csv-from-string [str delimiter]
+  "Reads a csv string and generates a lazy sequence of rows. If delimiter is nil, the default (\\,) is used."
+  (read-csv-from-reader (java.io.StringReader. str) delimiter))
 
 
 (defn- parse-csv [csv-seq]
@@ -23,14 +29,26 @@
   (let [header (first csv-seq)]
     (map #(zipmap header %) (rest csv-seq))))
 
+
 (defn parse
   "Converts a csv file to a lazy sequence of maps of the values where the keys are the items in the header row by default.
 The delimiter used by the parser can be changed by using the delimiter arg. When map-to-headers? is false, each line is returned represented as a vec."
   ([path delimiter map-to-headers?] (if map-to-headers?
 				      (parse-csv (read-csv path delimiter))
-				      (vec (read-csv path delimiter))))
+				      (map vec (read-csv path delimiter))))
   ([path delimiter] (parse-csv (read-csv path delimiter false)))
   ([path] (parse-csv (read-csv path nil false))))
+
+
+(defn parse-string
+  "Converts a csv string to a lazy sequence of maps of the values where the keys are the items in the header row by default.
+The delimiter used by the parser can be changed by using the delimiter arg. When map-to-headers? is false, each line is returned represented as a vec."
+  ([path delimiter map-to-headers?] (if map-to-headers?
+				      (parse-csv (read-csv-from-string path delimiter))
+				      (map vec (read-csv-from-string path delimiter))))
+  ([path delimiter] (parse-csv (read-csv-from-string path delimiter false)))
+  ([path] (parse-csv (read-csv-from-string path nil false))))
+
 
 (defn dump
   "Dumps a sequence of maps to a file given by path, pass a header to specify the order and columns to be written"


### PR DESCRIPTION
Hi, 

I added the possibility to let parse return a lazy-seq of vectors instead of maps and
added basic support for using custom delimiters.
I hope this project isn't dead, it's the only parser that worked for me...

Robin
