### PR TITLE
Add option for :escape character, read/write from java.io.File

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,11 @@
 /classes
 /checkouts
 pom.xml
+pom.xml.asc
 *jar
 lib
 classes
+.lein*
+.nrepl-port
+*.swp
+*.swo

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Maven:
 
 * [Robin Ramael](https://github.com/RobinRamael)
 * [Zach Tellman](https://github.com/ztellman)
-
+* [Ryan Sundberg](https://github.com/sundbry)
 
 ## License
 

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject opencsv-clj "2.0.2"
+(defproject opencsv-clj "2.1.0"
   :description "clojure wrapper for opencsv"
   :license {:name "Eclipse"
             :url "http://www.eclipse.org/legal/epl-v10.html"}

--- a/project.clj
+++ b/project.clj
@@ -4,6 +4,4 @@
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :url "http://github.com/grinnbearit/opencsv-clj"
   :dependencies [[org.clojure/clojure "1.6.0"]
-                 [net.sf.opencsv/opencsv "2.3"]]
-  :profiles {:dev {:dependencies [[midje "1.6.3"]]
-                   :plugins [[lein-midje "3.1.3"]]}})
+                 [net.sf.opencsv/opencsv "2.3"]])

--- a/src/opencsv_clj/core.clj
+++ b/src/opencsv_clj/core.clj
@@ -3,58 +3,75 @@
   (:refer-clojure :exclude [quote])
   (:require [clojure.java.io :as io])
   (:import [au.com.bytecode.opencsv CSVReader CSVWriter]
-           [java.io File Reader StringReader]))
+           [java.io File Reader StringReader StringWriter Writer]))
 
 (defn- make-reader
   [input]
   (cond 
-    (string? input)
-    (StringReader. input)
-
     (instance? Reader input)
     input
 
     (instance? File input)
-    (io/reader input)))
+    (io/reader input)
 
-(defn- make-csv-reader
-  [reader {:keys [separator quote escape]}]
-  (cond
-    (and (nil? separator) (nil? quote) (nil? escape))
-    (CSVReader. reader)
+    (string? input)
+    (StringReader. input)))
 
-    (and (nil? quote) (nil? escape))
-    (CSVReader. reader separator)
+(defn- make-writer
+  [output]
+  (cond 
+    (instance? Writer output)
+    output
 
-    (or (nil? escape)
-        (and (= \" quote) (= \" escape))
-        (and (nil? quote) (= CSVWriter/DEFAULT_QUOTE_CHARACTER escape)))
-    (CSVReader. reader 
-                (or separator CSVWriter/DEFAULT_SEPARATOR)
-                (or quote CSVWriter/DEFAULT_QUOTE_CHARACTER))
+    (instance? File output)
+    (io/writer output)
 
-    :else (CSVReader. reader 
-                      (or separator CSVWriter/DEFAULT_SEPARATOR)
-                      (or quote CSVWriter/DEFAULT_QUOTE_CHARACTER)
-                      escape)))
+    (string? output)
+    (let [wr (StringWriter.)]
+      (.write wr output)
+      wr)))
+
+(defmacro opencsv-construct
+  [constructor arg options]
+  `(let [separator# (:separator ~options)
+         quote# (:quote ~options)
+         escape# (:escape ~options)]
+     (cond
+       (and (nil? separator#) (nil? quote#) (nil? escape#))
+       (~constructor ~arg)
+
+       (and (nil? quote#) (nil? escape#))
+       (~constructor ~arg separator#)
+
+       (or (nil? escape#)
+           (and (= \" quote#) (= \" escape#))
+           (and (nil? quote#) (= CSVWriter/DEFAULT_QUOTE_CHARACTER escape#)))
+       (~constructor ~arg
+                     (or separator# CSVWriter/DEFAULT_SEPARATOR)
+                     (or quote# CSVWriter/DEFAULT_QUOTE_CHARACTER))
+
+       :else (~constructor ~arg
+                           (or separator# CSVWriter/DEFAULT_SEPARATOR)
+                           (or quote# CSVWriter/DEFAULT_QUOTE_CHARACTER)
+                           escape#))))
 
 (defn read-csv
-  "Reads CSV-data from input (String or java.io.Reader) into a lazy
+  "Reads CSV-data from input (String, java.io.Reader, java.io.File) into a lazy
   sequence of vectors."
   [input & {:keys [separator quote escape] :as options}]
-  (let [buffer (-> input make-reader (make-csv-reader options))
+  (let [reader (make-reader input) 
+        buffer (opencsv-construct CSVReader. reader options)
         read-row-seq (fn read-buffer [buf]
                        (when-let [nxt (.readNext buf)]
                          (lazy-seq (cons (vec nxt) (read-buffer buf)))))]
     (read-row-seq buffer)))
 
 (defn write-csv
-  "Writes data to writer in CSV-format."
-  [writer data & {:keys [separator quote]
-                  :or {separator CSVWriter/DEFAULT_SEPARATOR
-                       quote CSVWriter/DEFAULT_QUOTE_CHARACTER}
-                  :as options}]
-  (let [csv-writer (CSVWriter. writer separator quote)]
+  "Writes data to output (String, java.io.Writer, java.io.File) in CSV-format."
+  [output data & {:keys [separator quote escape] :as options}]
+  (let [writer (make-writer output)
+        csv-writer (opencsv-construct CSVWriter. writer options)]
     (doseq [entry (map into-array data)]
       (.writeNext csv-writer entry))
-    (.close csv-writer)))
+    (.close csv-writer)
+    output))

--- a/src/opencsv_clj/core.clj
+++ b/src/opencsv_clj/core.clj
@@ -1,15 +1,9 @@
 (ns opencsv-clj.core
   #^{:author "Sidhant Godiwala (grinnbearit)"}
+  (:refer-clojure :exclude [quote])
   (:require [clojure.java.io :as io])
   (:import [au.com.bytecode.opencsv CSVReader CSVWriter]
            [java.io File Reader StringReader]))
-
-(defn- opencsv-read [reader sep quote]
-  (let [buffer (CSVReader. reader sep quote)
-        read (fn read-buffer [buffer]
-               (when-let [nxt (.readNext buffer)]
-                 (lazy-seq (cons (vec nxt) (read-buffer buffer)))))]
-    (read buffer)))
 
 (defn- make-reader
   [input]
@@ -23,15 +17,36 @@
     (instance? File input)
     (io/reader input)))
 
+(defn- make-csv-reader
+  [reader {:keys [separator quote escape]}]
+  (cond
+    (and (nil? separator) (nil? quote) (nil? escape))
+    (CSVReader. reader)
+
+    (and (nil? quote) (nil? escape))
+    (CSVReader. reader separator)
+
+    (or (nil? escape)
+        (and (= \" quote) (= \" escape))
+        (and (nil? quote) (= CSVWriter/DEFAULT_QUOTE_CHARACTER escape)))
+    (CSVReader. reader 
+                (or separator CSVWriter/DEFAULT_SEPARATOR)
+                (or quote CSVWriter/DEFAULT_QUOTE_CHARACTER))
+
+    :else (CSVReader. reader 
+                      (or separator CSVWriter/DEFAULT_SEPARATOR)
+                      (or quote CSVWriter/DEFAULT_QUOTE_CHARACTER)
+                      escape)))
+
 (defn read-csv
   "Reads CSV-data from input (String or java.io.Reader) into a lazy
   sequence of vectors."
-  [input & {:keys [separator quote]
-            :or {separator CSVWriter/DEFAULT_SEPARATOR
-                 quote CSVWriter/DEFAULT_QUOTE_CHARACTER}
-            :as options}]
-  (opencsv-read (make-reader input) separator quote))
-
+  [input & {:keys [separator quote escape] :as options}]
+  (let [buffer (-> input make-reader (make-csv-reader options))
+        read-row-seq (fn read-buffer [buf]
+                       (when-let [nxt (.readNext buf)]
+                         (lazy-seq (cons (vec nxt) (read-buffer buf)))))]
+    (read-row-seq buffer)))
 
 (defn write-csv
   "Writes data to writer in CSV-format."

--- a/test/opencsv_clj/core_test.clj
+++ b/test/opencsv_clj/core_test.clj
@@ -47,9 +47,11 @@ air, moon roof, loaded\",4799.00")
 
 (deftest read-csv-file
   (let [file (File/createTempFile "opencsv-clj-test" ".csv")]
-    (spit file simple)
-    (let [data (csv/read-csv file)]
-      (is (= ["Year" "Make" "Model"] (first data))))))
+    (try
+      (spit file simple)
+      (let [data (csv/read-csv file)]
+        (is (= ["Year" "Make" "Model"] (first data))))
+      (finally (.delete file)))))
 
 (deftest read-doublequote-format
   (is (= [["quoted:" "escaped\"quotes\""]]
@@ -76,3 +78,19 @@ air, moon roof, loaded\",4799.00")
       (csv/write-csv string-writer (csv/read-csv simple)
                      :quote CSVWriter/NO_QUOTE_CHARACTER)
       (is (= simple (str string-writer))))))
+
+(deftest write-csv-file
+  (let [rows [["1" "2" "3"] ["4" "5" "6"]]
+        file (File/createTempFile "opencsv-clj-test" ".csv")]
+    (try
+      (is (instance? File (csv/write-csv file rows)))
+      (is (= rows (csv/read-csv file)))
+      (finally (.delete file)))))
+
+(deftest write-alternate-escape-char
+  (let [rows [["\"hello\"" "'world'"]]
+        file (File/createTempFile "opencsv-clj-test" ".csv")]
+    (try
+      (is (instance? File (csv/write-csv file rows :separator \' :quote \" :escape \\)))
+      (is (= rows (csv/read-csv file :separator \' :quote \" :escape \\)))
+      (finally (.delete file)))))

--- a/test/opencsv_clj/core_test.clj
+++ b/test/opencsv_clj/core_test.clj
@@ -1,9 +1,8 @@
 (ns opencsv-clj.core-test
-  (:use midje.sweet
-        opencsv-clj.core)
+  (:require [clojure.test :refer :all]
+            [opencsv-clj.core :as csv])
   (:import [java.io StringWriter]
            [au.com.bytecode.opencsv CSVWriter]))
-
 
 (def ^{:private true} simple
   "Year,Make,Model
@@ -27,28 +26,29 @@
 air, moon roof, loaded\",4799.00")
 
 
-(facts
- "reading"
- (let [csv (read-csv simple)]
-   (count csv) => 3
-   (count (first csv)) => 3
-   (first csv) => ["Year" "Make" "Model"]
-   (last csv) => ["2000" "Mercury" "Cougar"])
- (let [csv (read-csv simple-alt-sep :separator \;)]
-   (count csv) => 3
-   (count (first csv)) => 3
-   (first csv) => ["Year" "Make" "Model"]
-   (last csv) => ["2000" "Mercury" "Cougar"])
- (let [csv (read-csv complicated)]
-   (count csv) => 4
-   (count (first csv)) => 5
-   (first csv) => ["1997" "Ford" "E350" "ac, abs, moon" "3000.00"]
-   (last csv) => ["1996" "Jeep" "Grand Cherokee", "MUST SELL!\nair, moon roof, loaded" "4799.00"]))
+(deftest read-csv
+  (testing
+    "reading"
+    (let [csv (csv/read-csv simple)]
+      (is (= 3 (count csv)))
+      (is (= 3 (count (first csv))))
+      (is (= ["Year" "Make" "Model"] (first csv)))
+      (is (= ["2000" "Mercury" "Cougar"] (last csv))))
+    (let [csv (csv/read-csv simple-alt-sep :separator \;)]
+      (is (= 3 (count csv)))
+      (is (= 3 (count (first csv))))
+      (is (= ["Year" "Make" "Model"] (first csv)))
+      (is (= ["2000" "Mercury" "Cougar"] (last csv))))
+    (let [csv (csv/read-csv complicated)]
+      (is (= 4 (count csv)))
+      (is (= 5 (count (first csv))))
+      (is (= ["1997" "Ford" "E350" "ac, abs, moon" "3000.00"] (first csv)))
+      (is (= ["1996" "Jeep" "Grand Cherokee", "MUST SELL!\nair, moon roof, loaded" "4799.00"] (last csv))))))
 
-
-(facts
- "reading-and-writing"
- (let [string-writer (StringWriter.)]
-   (write-csv string-writer (read-csv simple)
-              :quote CSVWriter/NO_QUOTE_CHARACTER)
-   (str string-writer) => simple))
+(deftest read-and-write
+  (testing
+    "reading-and-writing"
+    (let [string-writer (StringWriter.)]
+      (csv/write-csv string-writer (csv/read-csv simple)
+                 :quote CSVWriter/NO_QUOTE_CHARACTER)
+      (is (= simple (str string-writer))))))

--- a/test/opencsv_clj/core_test.clj
+++ b/test/opencsv_clj/core_test.clj
@@ -51,10 +51,28 @@ air, moon roof, loaded\",4799.00")
     (let [data (csv/read-csv file)]
       (is (= ["Year" "Make" "Model"] (first data))))))
 
+(deftest read-doublequote-format
+  (is (= [["quoted:" "escaped\"quotes\""]]
+         (csv/read-csv "quoted:,\"escaped\"\"quotes\"\"\"\n"))))
+
+(deftest read-alternate-escape-char
+  (is (= [["quoted:" "escaped\"quotes\""]]
+         (csv/read-csv "quoted:,\"escaped\"\"quotes\"\"\"\n")))
+  (is (= [["quoted:" "escaped\"quotes\""]]
+         (csv/read-csv "quoted:,\"escaped\"\"quotes\"\"\"\n" :escape \")))
+  (is (= [["quoted:" "escaped\"quotes\""]]
+         (csv/read-csv "quoted:|\"escaped\"\"quotes\"\"\"\n" :separator \| :escape \")))
+  (is (= [["quoted:" "escaped\"quotes\""]]
+         (csv/read-csv "quoted:|\"escaped\"\"quotes\"\"\"\n" :separator \| :quote \" :escape \")))
+  (is (= [["quoted:" "escaped\"quotes\""]]
+         (csv/read-csv "quoted:,\"escaped\\\"quotes\\\"\"\n" :escape \\)))
+  (is (= [["\"foo\"" "\"bar\""]]
+         (csv/read-csv "\"\\\"foo\\\"\",\"\\\"bar\\\"\"\n" :escape \\))))
+
 (deftest read-and-write
   (testing
     "reading-and-writing"
     (let [string-writer (StringWriter.)]
       (csv/write-csv string-writer (csv/read-csv simple)
-                 :quote CSVWriter/NO_QUOTE_CHARACTER)
+                     :quote CSVWriter/NO_QUOTE_CHARACTER)
       (is (= simple (str string-writer))))))

--- a/test/opencsv_clj/core_test.clj
+++ b/test/opencsv_clj/core_test.clj
@@ -1,7 +1,7 @@
 (ns opencsv-clj.core-test
   (:require [clojure.test :refer :all]
             [opencsv-clj.core :as csv])
-  (:import [java.io StringWriter]
+  (:import [java.io File StringWriter]
            [au.com.bytecode.opencsv CSVWriter]))
 
 (def ^{:private true} simple
@@ -44,6 +44,12 @@ air, moon roof, loaded\",4799.00")
       (is (= 5 (count (first csv))))
       (is (= ["1997" "Ford" "E350" "ac, abs, moon" "3000.00"] (first csv)))
       (is (= ["1996" "Jeep" "Grand Cherokee", "MUST SELL!\nair, moon roof, loaded" "4799.00"] (last csv))))))
+
+(deftest read-csv-file
+  (let [file (File/createTempFile "opencsv-clj-test" ".csv")]
+    (spit file simple)
+    (let [data (csv/read-csv file)]
+      (is (= ["Year" "Make" "Model"] (first data))))))
 
 (deftest read-and-write
   (testing


### PR DESCRIPTION
This adds an option for an :escape character to read-csv and write-csv, and also adds support for reading and writing from a java.io.File. 

I also rewrote the tests using clojure.test, I hope you don't mind.
